### PR TITLE
Tweaking IAM group permissions for Bootstrap

### DIFF
--- a/bootstrap/iam.tf
+++ b/bootstrap/iam.tf
@@ -6,10 +6,13 @@ locals {
       member = "group:${var.gcp_trainer_group}"
       roles = [
         "roles/compute.admin",
+        "roles/compute.networkAdmin",
         "roles/dns.admin",
         "roles/iap.tunnelResourceAccessor",
         "roles/container.admin",
-        "roles/iam.serviceAccountAdmin"
+        "roles/iam.serviceAccountAdmin",
+        "roles/iam.serviceAccountUser",
+        "roles/serviceusage.serviceUsageAdmin"
       ]
     }
   ]


### PR DESCRIPTION
This pull request includes updates to the IAM roles in the `bootstrap/iam.tf` file to enhance permissions for the GCP trainer group.

Changes to IAM roles:

* Added `roles/compute.networkAdmin` to the list of roles.
* Added `roles/iam.serviceAccountUser` to the list of roles.
* Added `roles/serviceusage.serviceUsageAdmin` to the list of roles.